### PR TITLE
Need to use mock for readthedocs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -330,3 +330,13 @@ texinfo_documents = [
 
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {'https://docs.python.org/': None}
+
+from mock import Mock as MagicMock
+
+class Mock(MagicMock):
+    @classmethod
+    def __getattr__(cls, name):
+            return Mock()
+
+MOCK_MODULES = ['cjson', 'pycurl']
+sys.modules.update((mod_name, Mock()) for mod_name in MOCK_MODULES)

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -3,3 +3,4 @@ sphinx_rtd_theme
 sphinxcontrib-programoutput
 sphinxcontrib-autoanysrc
 pylint
+mock


### PR DESCRIPTION
https://github.com/rtfd/readthedoc.org/issues/929

readthedocs doesn't install c-code for python modules. This mean no pycurl, for example. This mock module is the recommended workaround. This should get DBS imported and documented correctly.