### PR TITLE
Updated installation script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ SiteAdminToolkit/*
 dbs/*
 dbs_src/*
 RestClient/*
-docs/*/*
+docs/dbs*/*
+docs/RestClient
 ConsistencyCheck/*
 WmAgentScripts/*

--- a/docs/pycurl/__init__.py
+++ b/docs/pycurl/__init__.py
@@ -1,0 +1,4 @@
+HTTPGET = None
+POST = None
+UPLOAD = None
+CUSTOMREQUEST = None

--- a/install.sh
+++ b/install.sh
@@ -17,3 +17,13 @@ then
     patch dbs/apis/dbsClient.py dbsClient.patch
 
 fi
+
+# If we're working on readthedocs, we need to use these dummy versions of cjson and pycurl
+
+if [ "$READTHEDOCS" = "True" ]
+then
+
+    ln -s docs/cjson cjson
+    ln -s docs/pycurl pycurl
+
+fi


### PR DESCRIPTION
Readthedocs does not allow c-based modules since it doesn't have a lot of the libraries. Before, I was using the module Mock to take care of this. It doesn't work for the "program-output" directive though, since that isn't imported by Sphinx itself. Adding the WmAgentScripts was breaking readthedocs.

Now there are dummy packages that should at least allow for argparse's help messages to be displayed properly.