### PR TITLE
Use sudo ./setup.py in package_test

### DIFF
--- a/test/package_test.sh
+++ b/test/package_test.sh
@@ -61,8 +61,15 @@ mkdir OpsSpace/"$package"
 cp --parents $(git ls-files) OpsSpace/"$package"
 
 cd OpsSpace || exit 1                     # Setup package as a user normally would
+
 # shellcheck disable=SC2154
-test -z "$IfSudo" && ./setup.py -p "$package" || sudo ./setup.py -p "$package"
+if [ -z "$IfSudo" ]
+then
+    ./setup.py -p "$package" 
+else 
+    sudo ./setup.py -p "$package"
+fi
+
 # shellcheck source=/dev/null
 . ~/.bashrc
 

--- a/test/package_test.sh
+++ b/test/package_test.sh
@@ -62,7 +62,7 @@ cp --parents $(git ls-files) OpsSpace/"$package"
 
 cd OpsSpace || exit 1                     # Setup package as a user normally would
 # shellcheck disable=SC2154
-"$IfSudo" ./setup.py -p "$package"        # Use sudo for the setup if asked with env variable
+test -z "$IfSudo" && ./setup.py -p "$package" || sudo ./setup.py -p "$package"
 # shellcheck source=/dev/null
 . ~/.bashrc
 


### PR DESCRIPTION
The mechanism to use sudo during a test was poorly written before, so that it crashed when not running in sudo.